### PR TITLE
Update KCL to 1.7.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ pulls in JAR files used to make use the Amazon [Kinesis Client Library][0].
 
 ## Compatability
 
-This buildpack is compatible with [version 1.0.0 of the `aws-kclrb` gem][1].  Be sure to pin your gem version accordingly:
+This buildpack is compatible with [version 1.0.1 of the `aws-kclrb` gem][1].  Be sure to pin your gem version accordingly:
 
 ```
-gem 'aws-kclrb', '= 1.0.0'
+gem 'aws-kclrb', '= 1.0.1'
 ```
 
-[1]: https://rubygems.org/gems/aws-kclrb/versions/1.0.0
+[1]: https://rubygems.org/gems/aws-kclrb/versions/1.0.1
 
 In general, this buildpack will be versioned in parallel with `aws-kclrb` so version numbers should match to guarantee compatability.
 
@@ -21,12 +21,12 @@ In general, this buildpack will be versioned in parallel with `aws-kclrb` so ver
 
 Since the JAR files in the buildpack have to correspond with the gem version, you probably want to pin buildpack versions you want to use when adding the buildpack:
 
-    $ heroku buildpacks:set https://github.com/apartmentlist/kinesis-client-buildpack.git#v1.0.0
+    $ heroku buildpacks:set https://github.com/apartmentlist/kinesis-client-buildpack.git#v1.0.1
 
     $ heroku buildpacks -a my-ruby-app
     === my-ruby-app Buildpack URLs
     1. heroku/ruby
-    2. https://github.com/apartmentlist/kinesis-client-buildpack.git#v1.0.0
+    2. https://github.com/apartmentlist/kinesis-client-buildpack.git#v1.0.1
 
 ## Details
 
@@ -46,12 +46,13 @@ The jar list is the most interesting part of this buildpack.  The list was gener
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>amazon-kinesis-client</artifactId>
-      <version>1.6.2</version>
+      <version>1.7.5</version>
     </dependency>
   </dependencies>
 </project>
-
 ```
+
+You can find the latest version of the `amazon-kinesis-client` in its [Maven repository listing][2].
 
 Once a new project is created with this file, the dependencies can be
 downloaded to a directory.  From the project root, one can simply:
@@ -61,14 +62,51 @@ mkdir jars
 mvn dependency:copy-dependencies -DoutputDirectory=jars
 ```
 
-These files can then be processed by `md5sum` to obtain the MD5 hashes.
-
 The group ID, artifact ID and versions for each can be extracted using `mvn`:
 
 ```
 mvn dependency:list
 ```
 
-Which can then be split on the `:` delimiter and spliced into the
+The result shows all dependencies and their versions:
+
+```
+com.amazonaws:aws-java-sdk-cloudwatch:jar:1.11.115:compile
+com.amazonaws:jmespath-java:jar:1.11.115:compile
+com.amazonaws:aws-java-sdk-s3:jar:1.11.115:compile
+commons-codec:commons-codec:jar:1.9:compile
+com.fasterxml.jackson.core:jackson-databind:jar:2.6.6:compile
+com.google.guava:guava:jar:18.0:compile
+joda-time:joda-time:jar:2.8.1:compile
+com.amazonaws:aws-java-sdk-kinesis:jar:1.11.115:compile
+commons-lang:commons-lang:jar:2.6:compile
+commons-logging:commons-logging:jar:1.1.3:compile
+com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.6.6:compile
+com.amazonaws:aws-java-sdk-core:jar:1.11.115:compile
+com.fasterxml.jackson.core:jackson-core:jar:2.6.6:compile
+software.amazon.ion:ion-java:jar:1.0.2:compile
+com.amazonaws:aws-java-sdk-kms:jar:1.11.115:compile
+com.amazonaws:aws-java-sdk-dynamodb:jar:1.11.115:compile
+com.amazonaws:amazon-kinesis-client:jar:1.7.5:compile
+org.apache.httpcomponents:httpclient:jar:4.5.2:compile
+org.apache.httpcomponents:httpcore:jar:4.4.4:compile
+com.fasterxml.jackson.core:jackson-annotations:jar:2.6.0:compile
+com.google.protobuf:protobuf-java:jar:2.6.1:compile
+```
+
+This listing can then be split on the `:` delimiter and spliced into the
 results of the MD5 output to generate the artifact list used by the
 buildpack.
+
+[2]: https://mvnrepository.com/artifact/com.amazonaws/amazon-kinesis-client
+
+## Testing
+
+If you want to modify the buildpack (probably the `compile` file) and test it, you can run it on a development machine:
+
+```
+cd bin
+STACK=cache ./compile . .
+```
+
+This will produce two directories `cache` and `jars` that contain the JARs.  You can remove them when you're finished testing.

--- a/bin/compile
+++ b/bin/compile
@@ -9,25 +9,28 @@ BUILD_DIR = "#{ARGV[0]}/jars"
 CACHE_DIR = "#{ARGV[1]}/#{ENV['STACK']}"
 
 MAVEN_PACKAGES = [
-  #[group id,                     artifact id,                    version,    MD5                           ],
-  ['com.amazonaws',               'amazon-kinesis-client',    '1.6.2',    'de8fd33f8c1b066f084d76e87d20c3c2'],
-  ['com.amazonaws',               'aws-java-sdk-cloudwatch',  '1.10.61',  '47895b2b9ca0cc44c0c24c3c86911a34'],
-  ['com.amazonaws',               'aws-java-sdk-core',        '1.10.61',  'd6b844a4e21a6be17d4d4895a0cb18ff'],
-  ['com.amazonaws',               'aws-java-sdk-dynamodb',    '1.10.61',  'bf60264be94c51887cd70c7095a95574'],
-  ['com.amazonaws',               'aws-java-sdk-kinesis',     '1.10.61',  'f31412629dac7ecea186cfd4378f8bd1'],
-  ['com.amazonaws',               'aws-java-sdk-kms',         '1.10.61',  'ed9f1062cc8708e5f283bcd72df6a67e'],
-  ['com.amazonaws',               'aws-java-sdk-s3',          '1.10.61',  '996572cbcced4b91aa5f0ee5a876171d'],
-  ['commons-codec',               'commons-codec',            '1.6',      '5970f54883b4831b24b97f1125ba27e6'],
-  ['commons-lang',                'commons-lang',             '2.6',      '4d5c1693079575b362edf41500630bbd'],
-  ['commons-logging',             'commons-logging',          '1.1.3',    '92eb5aabc1b47287de53d45c086a435c'],
-  ['com.google.guava',            'guava',                    '18.0',     '947641f6bb535b1d942d1bc387c45290'],
-  ['org.apache.httpcomponents',   'httpclient',               '4.3.6',    '2d29a27bb6c6b44bc8a608a0e5d09735'],
-  ['org.apache.httpcomponents',   'httpcore',                 '4.3.3',    'c26171852f9810cd3d2416604a387e71'],
-  ['com.fasterxml.jackson.core',  'jackson-annotations',      '2.5.0',    'db2a8e900965c9618cac9abec038e3de'],
-  ['com.fasterxml.jackson.core',  'jackson-core',             '2.5.3',    '5763215f9054614336ffa55d46a69e15'],
-  ['com.fasterxml.jackson.core',  'jackson-databind',         '2.5.3',    'b04f954ff7a76091cd6a303ebba8c67d'],
-  ['joda-time',                   'joda-time',                '2.8.1',    'c23002a0fac3455e92551e7f24500fa4'],
-  ['com.google.protobuf',         'protobuf-java',            '2.6.1',    '5d30d643648298898b2b31d609c3e7f0']
+ #[group id,                            artifact id,                version]
+  ['com.amazonaws',                     'amazon-kinesis-client',    '1.7.5'],
+  ['com.amazonaws',                     'aws-java-sdk-cloudwatch',  '1.11.115'],
+  ['com.amazonaws',                     'aws-java-sdk-core',        '1.11.115'],
+  ['com.amazonaws',                     'aws-java-sdk-dynamodb',    '1.11.115'],
+  ['com.amazonaws',                     'aws-java-sdk-kinesis',     '1.11.115'],
+  ['com.amazonaws',                     'aws-java-sdk-kms',         '1.11.115'],
+  ['com.amazonaws',                     'aws-java-sdk-s3',          '1.11.115'],
+  ['com.amazonaws',                     'jmespath-java',            '1.11.115'],
+  ['com.fasterxml.jackson.core',        'jackson-annotations',      '2.6.0'],
+  ['com.fasterxml.jackson.core',        'jackson-core',             '2.6.6'],
+  ['com.fasterxml.jackson.core',        'jackson-databind',         '2.6.6'],
+  ['com.fasterxml.jackson.dataformat',  'jackson-dataformat-cbor',  '2.6.6'],
+  ['com.google.guava',                  'guava',                    '18.0'],
+  ['com.google.protobuf',               'protobuf-java',            '2.6.1'],
+  ['commons-codec',                     'commons-codec',            '1.9'],
+  ['commons-lang',                      'commons-lang',             '2.6'],
+  ['commons-logging',                   'commons-logging',          '1.1.3'],
+  ['joda-time',                         'joda-time',                '2.8.1'],
+  ['org.apache.httpcomponents',         'httpclient',               '4.5.2'],
+  ['org.apache.httpcomponents',         'httpcore',                 '4.4.4'],
+  ['software.amazon.ion',               'ion-java',                 '1.0.2'],
 ]
 
 def ensure_directory(path)
@@ -36,19 +39,19 @@ def ensure_directory(path)
   end
 end
 
-def jar_name(_, artifact_id, version, _)
+def jar_name(_, artifact_id, version)
   "#{artifact_id}-#{version}.jar"
 end
 
-def jar_url(group_id, artifact_id, version, md5)
+def jar_url(group_id, artifact_id, version)
   group_path = group_id.gsub(/\./, '/')
-  jar_name = jar_name(group_id, artifact_id, version, md5)
+  jar_name = jar_name(group_id, artifact_id, version)
   "#{MAVEN_URL}/#{group_path}/#{artifact_id}/#{version}/#{jar_name}"
 end
 
-def download_maven_jar(group_id, artifact_id, version, md5)
-  jar_name = jar_name(group_id, artifact_id, version, md5)
-  jar_url = jar_url(group_id, artifact_id, version, md5)
+def download_maven_jar(group_id, artifact_id, version)
+  jar_name = jar_name(group_id, artifact_id, version)
+  jar_url = jar_url(group_id, artifact_id, version)
   cached_jar_file = File.join(CACHE_DIR, jar_name)
   File.open(cached_jar_file, 'wb') do |saved_file|
     open(jar_url, 'rb') do |read_file|
@@ -64,7 +67,6 @@ def download_jars_if_needed
     if !File.exist?(cached_jar_file)
       puts("Downloading '#{cached_jar_file}' from Maven...")
       download_maven_jar(*jar)
-      # TODO: Validate md5sums after download
     end
   end
 end


### PR DESCRIPTION
This should be compatible with v1.0.1 of the aws-kclrb gem.

Remove unused MD5sums.  We should do post-download verification using
SHA256, but that's a separate feature.

@yez @tcollier 