### PR TITLE
Add JVM buildpack to support Kinesis 1.8.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 ## `kinesis-client-buildpack` for Heroku
 
-This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) that
-pulls in JAR files used to make use the Amazon [Kinesis Client Library][0].
+This is a [Heroku buildpack][0] that pulls in JAR files used to make use the Amazon [Kinesis Client Library][1].  Since Java 8 is required to make use of those JAR files, this buildpack is built atop the official [Heroku JVM buildpack][2].
 
-[0]: http://docs.aws.amazon.com/kinesis/latest/dev/developing-consumers-with-kcl.html
+[0]: http://devcenter.heroku.com/articles/buildpacks
+[1]: http://docs.aws.amazon.com/kinesis/latest/dev/developing-consumers-with-kcl.html
+[2]: https://github.com/heroku/heroku-buildpack-jvm-common
 
 ## Compatability
 
-This buildpack is compatible with [version 1.0.1 of the `aws-kclrb` gem][1].  Be sure to pin your gem version accordingly:
+This buildpack is compatible with [version 1.0.1 of the `aws-kclrb` gem][3].  Be sure to pin your gem version accordingly:
 
 ```
 gem 'aws-kclrb', '= 1.0.1'
 ```
 
-[1]: https://rubygems.org/gems/aws-kclrb/versions/1.0.1
+[3]: https://rubygems.org/gems/aws-kclrb/versions/1.0.1
 
 In general, this buildpack will be versioned in parallel with `aws-kclrb` so version numbers should match to guarantee compatibility.
 
@@ -21,12 +22,12 @@ In general, this buildpack will be versioned in parallel with `aws-kclrb` so ver
 
 Since the JAR files in the buildpack have to correspond with the gem version, you probably want to pin buildpack versions you want to use when adding the buildpack:
 
-    $ heroku buildpacks:set https://github.com/apartmentlist/kinesis-client-buildpack.git#v1.0.1
+    $ heroku buildpacks:set https://github.com/apartmentlist/kinesis-client-buildpack.git#v1.0.1.2
 
     $ heroku buildpacks -a my-ruby-app
     === my-ruby-app Buildpack URLs
     1. heroku/ruby
-    2. https://github.com/apartmentlist/kinesis-client-buildpack.git#v1.0.1
+    2. https://github.com/apartmentlist/kinesis-client-buildpack.git#v1.0.1.2
 
 ## Details
 
@@ -52,7 +53,9 @@ The jar list is the most interesting part of this buildpack.  The list was gener
 </project>
 ```
 
-You can find the latest version of the `amazon-kinesis-client` in its [Maven repository listing][2].
+You can find the latest version of the `amazon-kinesis-client` in its [Maven repository listing][4].
+
+[4]: https://mvnrepository.com/artifact/com.amazonaws/amazon-kinesis-client
 
 Once a new project is created with this file, the dependencies can be
 downloaded to a directory.  From the project root, one can simply:
@@ -96,15 +99,13 @@ com.google.protobuf:protobuf-java:jar:2.6.1:compile
 
 This listing can then be split out to update the list of jars and versions that should be downloaded in the `compile` script.
 
-[2]: https://mvnrepository.com/artifact/com.amazonaws/amazon-kinesis-client
-
 ## Testing
 
 If you want to modify the buildpack (probably the `compile` file) and test it, you can run it on a development machine:
 
 ```
-cd bin
-STACK=cache ./compile . .
+mkdir tmp
+STACK=heroku-16 ./bin/compile tmp tmp
 ```
 
 This will produce two directories `cache` and `jars` that contain the JARs.  You can remove them when you're finished testing.

--- a/bin/compile
+++ b/bin/compile
@@ -5,6 +5,7 @@ require 'fileutils'
 require 'open-uri'
 
 MAVEN_URL = 'https://repo1.maven.org/maven2'
+JDK_DIR = ARGV[0]
 BUILD_DIR = "#{ARGV[0]}/jars"
 CACHE_DIR = "#{ARGV[1]}/#{ENV['STACK']}"
 
@@ -32,6 +33,16 @@ MAVEN_PACKAGES = [
   ['org.apache.httpcomponents',         'httpcore',                 '4.4.4'],
   ['software.amazon.ion',               'ion-java',                 '1.0.2'],
 ]
+
+def install_java(jdk_dir)
+  script_dir = File.dirname(__FILE__)
+  script = File.join(File.expand_path(script_dir), 'install_java')
+  result = %x(#{script} #{jdk_dir})
+  unless $? == 0
+    puts("Error while installing Java:\n#{result}")
+    fail("Failed to install Java...exiting")
+  end
+end
 
 def ensure_directory(path)
   unless File.directory?(path)
@@ -81,6 +92,7 @@ def copy_jars_to_app
   end
 end
 
+install_java(JDK_DIR)
 ensure_directory(BUILD_DIR)
 ensure_directory(CACHE_DIR)
 download_jars_if_needed

--- a/bin/install_java
+++ b/bin/install_java
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Based upon example code in the readme for the JVM buildpack:
+#  https://github.com/heroku/heroku-buildpack-jvm-common#usage-from-a-buildpack
+
+BUILD_DIR=$1
+
+JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/jvm-common.tgz}
+mkdir -p /tmp/jvm-common
+curl --silent --location $JVM_COMMON_BUILDPACK | tar xzm -C /tmp/jvm-common --strip-components=1
+. /tmp/jvm-common/bin/util
+. /tmp/jvm-common/bin/java
+
+# install JDK
+javaVersion=$(detect_java_version ${BUILD_DIR})
+
+install_java ${BUILD_DIR} ${javaVersion}


### PR DESCRIPTION
This pulls in assets from Heroku's official [JVM buildpack][0] so that
clients don't have to further manipulate their buildpack stack after
adding this buildpack.

[0]: https://github.com/heroku/heroku-buildpack-jvm-common